### PR TITLE
Removed JSONParser instance.

### DIFF
--- a/app/src/main/java/rocks/athrow/android_udacity_reviews/data/FetchTask.java
+++ b/app/src/main/java/rocks/athrow/android_udacity_reviews/data/FetchTask.java
@@ -74,11 +74,10 @@ public class FetchTask extends AsyncTask<String, Void, Void> {
         jsonResults = API.callAPI(module, dateStart, null);
         //Parse the results if not null
         if (jsonResults != null) {
-            JSONParser parser = new JSONParser(mContext);
             if (module.equals(MODULE_REVIEWS)) {
-                parsedResults = parser.parseReviews(jsonResults);
+                parsedResults = JSONParser.parseReviews(jsonResults);
             } else if (module.equals(MODULE_FEEDBACKS)) {
-                parsedResults = parser.parseFeedbacks(jsonResults);
+                parsedResults = JSONParser.parseFeedbacks(jsonResults);
             }
             // The parsedResults are not null, update the Realm database
             if (parsedResults != null) {

--- a/app/src/main/java/rocks/athrow/android_udacity_reviews/data/JSONParser.java
+++ b/app/src/main/java/rocks/athrow/android_udacity_reviews/data/JSONParser.java
@@ -11,15 +11,10 @@ import org.json.JSONObject;
 /**
  * Created by joselopez on 7/5/16.
  */
-class JSONParser {
+final class JSONParser {
 
-    private static final String LOG_TAG = API.class.getSimpleName();
-    private ContentValues[] mContentValues;
-    private Context mContext;
-
-    // Constructor
-    public JSONParser(Context context) {
-        this.mContext = context;
+    private JSONParser(){
+        throw new AssertionError("No JSONParser instances for you!");
     }
 
     /**
@@ -28,11 +23,14 @@ class JSONParser {
      * @param reviewsJSON a string of results from submissions completed API call
      * @return a ContentValues array with the results as ContentValues
      */
-    public ContentValues[] parseReviews(String reviewsJSON) {
+    public static ContentValues[] parseReviews(String reviewsJSON) {
+        ContentValues[] contentValues = new ContentValues[0];
+
         try {
             JSONArray reviewsArray = new JSONArray(reviewsJSON);
             int reviewsQty = reviewsArray.length();
-            mContentValues = new ContentValues[reviewsQty];
+            contentValues = new ContentValues[reviewsQty];
+
             for (int i = 0; i < reviewsQty; i++) {
                 JSONObject reviewRecord = reviewsArray.getJSONObject(i);
                 // Create a ContentValues object
@@ -107,14 +105,14 @@ class JSONParser {
                 //----------------------------------------------------------------------------------
                 // Add the ContentValues to the Array
                 //----------------------------------------------------------------------------------
-                mContentValues[i] = reviewValues;
+                contentValues[i] = reviewValues;
             }
 
         } catch (JSONException e) {
             e.printStackTrace();
         }
 
-        return mContentValues;
+        return contentValues;
     }
 
     /**
@@ -123,11 +121,13 @@ class JSONParser {
      * @param feedbacksJSON a string of results from student feedbacks API call
      * @return a ContentValues array with the results as ContentValues
      */
-    public ContentValues[] parseFeedbacks(String feedbacksJSON) {
+    public static ContentValues[] parseFeedbacks(String feedbacksJSON) {
+        ContentValues[] contentValues = new ContentValues[0];
         try {
             JSONArray feedbacksArray = new JSONArray(feedbacksJSON);
             int feedbacksQty = feedbacksArray.length();
-            mContentValues = new ContentValues[feedbacksQty];
+
+            contentValues = new ContentValues[feedbacksQty];
             for (int i = 0; i < feedbacksQty; i++) {
                 JSONObject reviewRecord = feedbacksArray.getJSONObject(i);
                 // Create a ContentValues object
@@ -168,14 +168,14 @@ class JSONParser {
                 //----------------------------------------------------------------------------------
                 // Add the ContentValues to the Array
                 //----------------------------------------------------------------------------------
-                mContentValues[i] = reviewValues;
+                contentValues[i] = reviewValues;
             }
 
         } catch (JSONException e) {
             e.printStackTrace();
         }
 
-        return mContentValues;
+        return contentValues;
     }
 
 }

--- a/app/src/main/java/rocks/athrow/android_udacity_reviews/util/Constants.java
+++ b/app/src/main/java/rocks/athrow/android_udacity_reviews/util/Constants.java
@@ -1,7 +1,7 @@
 package rocks.athrow.android_udacity_reviews.util;
 
 /**
- * Created by Izodine on 8/1/2016.
+ * Created by Anthony M. Santiago on 8/1/2016.
  * 
  * Class to hold global constants.
  */


### PR DESCRIPTION
The `JSONParser` was designed to be instantiated. After further evaluation, I found a way to get rid of the instance. The `Context` field wasn't actually used, and the `ContentValues` field could be made into a local variable. This will help performance a tiny bit, as static methods are faster to call than non-static methods.

Lastly, one of the classes I made was using the default "author" template, which was using "Izodine". I changed it to my actual name with the class I created in a prior pull request.
